### PR TITLE
adding required setting to properties file

### DIFF
--- a/aws-s3-sink/src/main/resources/application.properties
+++ b/aws-s3-sink/src/main/resources/application.properties
@@ -28,6 +28,11 @@ camel.component.knative.typeId=
 
 # Kamelet sink properties
 # camel.kamelet.aws-s3-sink.<property-name>=
+camel.kamelet.aws-s3-sink.accessKey=
+camel.kamelet.aws-s3-sink.secretKey=
+camel.kamelet.aws-s3-sink.region=
+camel.kamelet.aws-s3-sink.bucketNameOrArn=
+
 
 # ConfigMap and secret based configuration
 camel.kubernetes-config.mount-path-configmaps=/etc/camel/conf.d/_configmaps/kn-sink-config


### PR DESCRIPTION
With out this fix, I am getting:

```
s3-sink-deployment-7886f69cc-khspt sink Caused by: java.lang.IllegalArgumentException: Route template aws-s3-sink the following mandatory parameters must be provided: bucketNameOrArn, region
s3-sink-deployment-7886f69cc-khspt sink 	at org.apache.camel.impl.DefaultModel.addRouteFromTemplate(DefaultModel.java:477)
s3-sink-deployment-7886f69cc-khspt sink 	at org.apache.camel.impl.DefaultModel.addRouteFromTemplate(DefaultModel.java:416)
s3-sink-deployment-7886f69cc-khspt sink 	at org.apache.camel.impl.DefaultCamelContext.addRouteFromTemplate(DefaultCamelContext.java:362)
s3-sink-deployment-7886f69cc-khspt sink 	at org.apache.camel.component.kamelet.KameletComponent$LifecycleHandler.createRouteForEndpoint(KameletComponent.java:433)
s3-sink-deployment-7886f69cc-khspt sink 	... 28 more
s3-sink-deployment-7886f69cc-khspt sink 

```


