### PR TITLE
Add initial support to produce images in ConfigMap as release artifact

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,6 +17,9 @@
 # shellcheck disable=SC1090
 source "$(go run knative.dev/hack/cmd/script release.sh)"
 
+CONFIMAP_YAML="eventing-integrations-images.yaml"
+IMAGES_TXT="images.txt"
+
 function build_release() {
   header "Building images"
 
@@ -25,6 +28,38 @@ function build_release() {
   ./mvnw clean package -P knative -DskipTests || return $?
 
   echo "Image build & push completed"
+
+  echo "Collect image shas into ConfigMap"
+  generate_configMap
+
+  ARTIFACTS_TO_PUBLISH="${CONFIMAP_YAML} ${IMAGES_TXT}"
+  sha256sum ${ARTIFACTS_TO_PUBLISH} >checksums.txt
+  ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt"
+  echo "Checksum:"
+  cat checksums.txt
+}
+
+function generate_configMap() {
+  image_digests=$(find . -name "jib-image.digest")
+
+  cat <<EOF > ${CONFIMAP_YAML}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: eventing-integrations-images
+    data:
+EOF
+
+  # shellcheck disable=SC2068
+  for image_digest_path in ${image_digests[@]}; do
+    echo "Processing image: ${image_digest_path}"
+    image=$(echo "${image_digest_path}" | cut -d "/" -f2)
+    image_digest=$(cat "${image_digest_path}")
+    # Config map with key value imageName:imageRef
+    echo "  ${image}: ${KO_DOCKER_REPO}/${image}:${image_digest}" >>${CONFIMAP_YAML}
+    # Storing plain image URLs in a txt file
+    echo "${KO_DOCKER_REPO}/${image}:${image_digest}" >>${IMAGES_TXT}
+  done
 }
 
 main "$@"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add initial support to produce images in ConfigMap as release artifact

/cc @matzew 