### PR TITLE
Fix separator for image SHA in integrations images refs

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -82,9 +82,9 @@ EOF
     image=$(echo "${image_digest_path}" | cut -d "/" -f2)
     image_digest=$(cat "${image_digest_path}")
     # Config map with key value imageName:imageRef
-    echo "  ${image}: ${KO_DOCKER_REPO}/${image}:${image_digest}" >>${INTEGRATION_CONFIGMAP_YAML}
+    echo "  ${image}: ${KO_DOCKER_REPO}/${image}@${image_digest}" >>${INTEGRATION_CONFIGMAP_YAML}
     # Storing plain image URLs in a txt file
-    echo "${KO_DOCKER_REPO}/${image}:${image_digest}" >>${IMAGES_TXT}
+    echo "${KO_DOCKER_REPO}/${image}@${image_digest}" >>${IMAGES_TXT}
   done
 }
 


### PR DESCRIPTION
Current YAML

```
pierdipi@pierdipi knobots (update-eventing-eventing-integrations) $ curl https://storage.googleapis.com/knative-nightly/eventing-integrations/latest/eventing-integrations-images.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: eventing-integrations-images
data:
  aws-s3-sink: gcr.io/knative-nightly/aws-s3-sink:sha256:7a989750d3c34e08e7a7a4a300d6640d851676d6a3c738e6efb595ca4b25e6af
  aws-sqs-source: gcr.io/knative-nightly/aws-sqs-source:sha256:8009aa69d3108847ed5fadcc3479e215ca93e29c63969d90a6db80a796d2e9e2
  aws-sns-sink: gcr.io/knative-nightly/aws-sns-sink:sha256:9c668aa11cff1d1ccfbcd43c58d13c9264553018869c3af3ba6e2a32b2454feb
  timer-source: gcr.io/knative-nightly/timer-source:sha256:d825c8a1e06195c53eef2e49396596c4d1596ac061cf5abadb1fd3a7a4bbdf39
  aws-ddb-streams-source: gcr.io/knative-nightly/aws-ddb-streams-source:sha256:5b908669f42199ba0fda971c7eb20b16ac2b07168323a1f9fc16a583db94e463
  aws-s3-source: gcr.io/knative-nightly/aws-s3-source:sha256:9756fa33242d55a36bc9ed7da701080f1021df43078d36b8f1c638fb61b74a85
  log-sink: gcr.io/knative-nightly/log-sink:sha256:454b339523e363d7c443c00ebfe2484f88a8bef39cb4a76ac2d5f31d4f21f565
  aws-sqs-sink: gcr.io/knative-nightly/aws-sqs-sink:sha256:70bfabec2b3b606a22282853f2c6dc6d09cd1dc954cd50784928f3273e98e370
```