### PR TITLE
bump maven plugins versions and remove redundant version definitions

### DIFF
--- a/aws-ddb-streams-source/pom.xml
+++ b/aws-ddb-streams-source/pom.xml
@@ -120,15 +120,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/aws-s3-sink/pom.xml
+++ b/aws-s3-sink/pom.xml
@@ -101,15 +101,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/aws-s3-source/pom.xml
+++ b/aws-s3-source/pom.xml
@@ -107,15 +107,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/aws-sns-sink/pom.xml
+++ b/aws-sns-sink/pom.xml
@@ -106,15 +106,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/aws-sqs-sink/pom.xml
+++ b/aws-sqs-sink/pom.xml
@@ -101,15 +101,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/aws-sqs-source/pom.xml
+++ b/aws-sqs-source/pom.xml
@@ -107,15 +107,12 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/log-sink/pom.xml
+++ b/log-sink/pom.xml
@@ -91,15 +91,12 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <failsafe.useModulePath>false</failsafe.useModulePath>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,10 +29,10 @@
 
         <!-- needed from tooling/archetypes -->
         <maven-version>3.9.9</maven-version>
-        <maven-archetype-plugin-version>3.2.1</maven-archetype-plugin-version>
-        <maven-archetype-packaging-version>3.2.1</maven-archetype-packaging-version>
+        <maven-archetype-plugin-version>3.4.0</maven-archetype-plugin-version>
+        <maven-archetype-packaging-version>3.4.0</maven-archetype-packaging-version>
 
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.3</surefire-plugin.version>
         <skipITs>true</skipITs>
     </properties>
 

--- a/timer-source/pom.xml
+++ b/timer-source/pom.xml
@@ -105,15 +105,12 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
# Changes

- :broom: remove redundant plugin version definitions from child poms
- :broom: bump maven plugin versions
