### PR TITLE
Fix Transform-jsonata image path for eventing-transformations-images.yaml

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 export JSONATA_IMAGE_TAG=${TAG:-$(git rev-parse HEAD)}
 
-export TRANSFORM_JSONATA_IMAGE_WITH_TAG="${KO_DOCKER_REPO:-kind.local}/transform-jsonata:${JSONATA_IMAGE_TAG}"
+export TRANSFORM_JSONATA_IMAGE_REPO="${KO_DOCKER_REPO:-kind.local}/transform-jsonata"
+export TRANSFORM_JSONATA_IMAGE_WITH_TAG="${TRANSFORM_JSONATA_IMAGE_REPO}:${JSONATA_IMAGE_TAG}"
 
 [[ ! -v REPO_ROOT_DIR ]] && REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 readonly REPO_ROOT_DIR
@@ -55,7 +56,7 @@ function push_transform_jsonata_image() {
     docker manifest push "${TRANSFORM_JSONATA_IMAGE_WITH_TAG}" || return $?
 
     digest=$(docker buildx imagetools inspect "${TRANSFORM_JSONATA_IMAGE_WITH_TAG}" --format "{{json .Manifest.Digest }}" | tr -d '"')
-    TRANSFORM_JSONATA_IMAGE="${TRANSFORM_JSONATA_IMAGE_WITH_TAG}@${digest}"
+    TRANSFORM_JSONATA_IMAGE="${TRANSFORM_JSONATA_IMAGE_REPO}@${digest}"
     export TRANSFORM_JSONATA_IMAGE
 
     echo "TRANSFORM_JSONATA_IMAGE=${TRANSFORM_JSONATA_IMAGE}"


### PR DESCRIPTION
Currently we have invalid paths to the jsonata image in the eventing-transformations-images.yaml:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: eventing-transformations-images
  namespace: knative-eventing
  labels:
    app.kubernetes.io/version: "v1.19.0"
data:
  transform-jsonata: gcr.io/knative-releases/transform-jsonata:v1.19.0@sha256:d362cb7ad8b779a83d66d136e5de0d51bd764698d216df9f3ead1eb76bfd7d70
```

This PR addresses it and fixes the path of the transform-jsonata image